### PR TITLE
[Ad-hoc] Account for LazyUuidFromString on Uuid generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "ramsey/uuid": "^4.0"
+        "ramsey/uuid": "^4.1"
     },
     "require-dev": {
         "infection/infection": "^0.16",

--- a/tests/IdentifierGenerator/RamseyUuidTest.php
+++ b/tests/IdentifierGenerator/RamseyUuidTest.php
@@ -5,7 +5,7 @@ namespace Chimera\Tests\IdentifierGenerator;
 
 use Chimera\IdentifierGenerator\RamseyUuid;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Rfc4122\UuidV4;
+use Ramsey\Uuid\Lazy\LazyUuidFromString;
 
 final class RamseyUuidTest extends TestCase
 {
@@ -19,7 +19,7 @@ final class RamseyUuidTest extends TestCase
         $generator  = new RamseyUuid();
         $identifier = $generator->generate();
 
-        self::assertInstanceOf(UuidV4::class, $identifier);
+        self::assertInstanceOf(LazyUuidFromString::class, $identifier);
     }
 
     /**
@@ -34,8 +34,8 @@ final class RamseyUuidTest extends TestCase
         $identifier1 = $generator->generate();
         $identifier2 = $generator->generate();
 
-        self::assertInstanceOf(UuidV4::class, $identifier1);
-        self::assertInstanceOf(UuidV4::class, $identifier2);
+        self::assertInstanceOf(LazyUuidFromString::class, $identifier1);
+        self::assertInstanceOf(LazyUuidFromString::class, $identifier2);
 
         self::assertNotEquals($identifier1, $identifier2);
         self::assertNotSame((string) $identifier1, (string) $identifier2);


### PR DESCRIPTION
The generation of Uuid objects received a substantial improvement
in this PR https://github.com/ramsey/uuid/pull/324 which introduced
the new object being returned from the default UuidFactory.