### PR TITLE
Remove deprecated method

### DIFF
--- a/src/ExecuteCommand.php
+++ b/src/ExecuteCommand.php
@@ -27,16 +27,4 @@ final class ExecuteCommand
     {
         $this->bus->handle($this->messageCreator->create($this->command, $input));
     }
-
-    /**
-     * Returns the name of the command to be handled
-     *
-     * @deprecated
-     *
-     * @return class-string
-     */
-    public function getCommand(): string
-    {
-        return $this->command;
-    }
 }

--- a/src/ExecuteQuery.php
+++ b/src/ExecuteQuery.php
@@ -27,16 +27,4 @@ final class ExecuteQuery
     {
         return $this->bus->handle($this->messageCreator->create($this->query, $input));
     }
-
-    /**
-     * Returns the name of the query to be handled
-     *
-     * @deprecated
-     *
-     * @return class-string
-     */
-    public function getQuery(): string
-    {
-        return $this->query;
-    }
 }

--- a/tests/ExecuteCommandTest.php
+++ b/tests/ExecuteCommandTest.php
@@ -15,14 +15,13 @@ use stdClass;
 /** @coversDefaultClass \Chimera\ExecuteCommand */
 final class ExecuteCommandTest extends TestCase
 {
-    /** @var ServiceBus&MockObject */
-    private ServiceBus $bus;
-
-    /** @var Input&MockObject */
-    private Input $input;
-
-    /** @var MessageCreator&MockObject */
-    private MessageCreator $messageCreator;
+    // phpcs:disable PSR12.Operators.OperatorSpacing.NoSpaceBefore -- PHPCS isn't ready for PHP 8.1 features yet
+    // phpcs:disable PSR12.Operators.OperatorSpacing.NoSpaceAfter
+    private ServiceBus&MockObject $bus;
+    private Input&MockObject $input;
+    private MessageCreator&MockObject $messageCreator;
+    // phpcs:enable PSR12.Operators.OperatorSpacing.NoSpaceBefore
+    // phpcs:enable PSR12.Operators.OperatorSpacing.NoSpaceAfter
 
     /** @before */
     public function createDependencies(): void

--- a/tests/ExecuteCommandTest.php
+++ b/tests/ExecuteCommandTest.php
@@ -35,19 +35,6 @@ final class ExecuteCommandTest extends TestCase
      * @test
      *
      * @covers ::__construct()
-     * @covers ::getCommand()
-     */
-    public function getCommandShouldReturnTheNameOfTheMessageToBeExecuted(): void
-    {
-        $action = new ExecuteCommand($this->bus, $this->messageCreator, SampleMessage::class);
-
-        self::assertSame(SampleMessage::class, $action->getCommand()); // @phpstan-ignore-line we'll remove this soon
-    }
-
-    /**
-     * @test
-     *
-     * @covers ::__construct()
      * @covers ::execute()
      */
     public function executeShouldCreateTheMessageAndHandleItWithTheBus(): void

--- a/tests/ExecuteQueryTest.php
+++ b/tests/ExecuteQueryTest.php
@@ -35,19 +35,6 @@ final class ExecuteQueryTest extends TestCase
      * @test
      *
      * @covers ::__construct()
-     * @covers ::getQuery()
-     */
-    public function getQueryShouldReturnTheNameOfTheMessageToBeExecuted(): void
-    {
-        $action = new ExecuteQuery($this->bus, $this->messageCreator, SampleMessage::class);
-
-        self::assertSame(SampleMessage::class, $action->getQuery()); // @phpstan-ignore-line we'll remove this soon
-    }
-
-    /**
-     * @test
-     *
-     * @covers ::__construct()
      * @covers ::fetch()
      */
     public function fetchShouldCreateTheMessageAndHandleItWithTheBus(): void

--- a/tests/ExecuteQueryTest.php
+++ b/tests/ExecuteQueryTest.php
@@ -15,14 +15,13 @@ use stdClass;
 /** @coversDefaultClass \Chimera\ExecuteQuery */
 final class ExecuteQueryTest extends TestCase
 {
-    /** @var ServiceBus&MockObject */
-    private ServiceBus $bus;
-
-    /** @var Input&MockObject */
-    private Input $input;
-
-    /** @var MessageCreator&MockObject */
-    private MessageCreator $messageCreator;
+    // phpcs:disable PSR12.Operators.OperatorSpacing.NoSpaceBefore -- PHPCS isn't ready for PHP 8.1 features yet
+    // phpcs:disable PSR12.Operators.OperatorSpacing.NoSpaceAfter
+    private ServiceBus&MockObject $bus;
+    private Input&MockObject $input;
+    private MessageCreator&MockObject $messageCreator;
+    // phpcs:enable PSR12.Operators.OperatorSpacing.NoSpaceBefore
+    // phpcs:enable PSR12.Operators.OperatorSpacing.NoSpaceAfter
 
     /** @before */
     public function createDependencies(): void


### PR DESCRIPTION
These were just getters and with the `readonly` modifier we don't need them anymore.