### PR TITLE
Report coverage via a dedicated job

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -55,7 +55,4 @@ jobs:
         run: "composer install --no-interaction --no-progress"
 
       - name: "Infection"
-        run: "make infection PHPUNIT_FLAGS=--coverage-clover=coverage.xml INFECTION_FLAGS=--logger-github"
-
-      - name: "Upload Code Coverage"
-        uses: "codecov/codecov-action@v2.1.0"
+        run: "make infection INFECTION_FLAGS=--logger-github"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -107,3 +107,62 @@ jobs:
 
       - name: "Tests"
         run: "make phpunit"
+
+  coverage:
+    name: "Test coverage"
+
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      matrix:
+        dependencies:
+          - "locked"
+        php-version:
+          - "8.1"
+        operating-system:
+          - "ubuntu-latest"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2.4.0"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@2.17.0"
+        with:
+          coverage: "xdebug"
+          php-version: "${{ matrix.php-version }}"
+          ini-values: memory_limit=-1
+          tools: composer:v2, cs2pr
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: "Cache dependencies"
+        uses: "actions/cache@v2.1.7"
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
+
+      - name: "Install lowest dependencies"
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: "composer update --prefer-lowest --no-interaction --no-progress"
+
+      - name: "Install highest dependencies"
+        if: ${{ matrix.dependencies == 'highest' }}
+        run: "composer update --no-interaction --no-progress"
+
+      - name: "Install locked dependencies"
+        if: ${{ matrix.dependencies == 'locked' }}
+        run: "composer install --no-interaction --no-progress"
+
+      - name: "Install development dependencies"
+        if: ${{ matrix.dependencies == 'development' }}
+        run: "composer config minimum-stability dev && composer update --no-interaction --no-progress"
+
+      - name: "Generage coverage"
+        run: "make phpunit PHPUNIT_FLAGS='--coverage-text --coverage-clover=coverage.xml'"
+
+      - name: "Upload Coverage"
+        uses: "codecov/codecov-action@v2.1.0"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ vendor/composer/installed.json: composer.json composer.lock
 
 .PHONY: phpunit
 phpunit:
-	@php -dzend.assertions=1 vendor/bin/phpunit
+	@php -dzend.assertions=1 vendor/bin/phpunit $(PHPUNIT_FLAGS)
 
 .PHONY: infection
 infection:


### PR DESCRIPTION
The mutation test job was being used to also generate and upload the coverage report, which broke when we stopped splitting phpunit and infection commands.

This puts things to work again by creating a new job on the pipeline.